### PR TITLE
Add platform support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ According to the above requirement, we developed the apache2nginx tool. The goal
 
 ## Download and Installation 
 
-You could download source code or binary file (i386 or x86_64) to use.
+You can download a Linux executable (for both i386/x86_64) or compile from source. If you're on a Mac, compiling from source has been tested with OS X Yosemite.
 
-### Download Binary 
+### Download Linux Binary
 
 ```bash
 $ wget https://github.com/downloads/nhnc-nginx/apache2nginx/apache2nginx-1.0.1-bin.i386.tar.bz2
@@ -33,7 +33,7 @@ $ ./apache2nginx -h
 Step 1: Download and unzip source code to the above directory.
 
 ```bash
-$ wget https://github.com/nhnc-nginx/apache2nginx/zipball/master
+$ wget https://github.com/nhnc-nginx/apache2nginx/zipball/master -O nhnc-nginx-apache2nginx.zip
 $ unzip nhnc-nginx-apache2nginx.zip
 ```
 


### PR DESCRIPTION
Executing the binary on OS X Yosemite gives the error below:

```
$ ./apache2nginx 
-bash: ./apache2nginx: cannot execute binary file
$ file apache2nginx
apache2nginx: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.9, stripped
```

As the `file` command shows it's a Linux executable (`ELF` format), which won't work on Darwin (`Mach-O` format)

This PR is to update the README accordingly.
